### PR TITLE
fix: conditionally renders second type badge if pokemon is single type

### DIFF
--- a/src/pages/PokemonDetailPage/index.jsx
+++ b/src/pages/PokemonDetailPage/index.jsx
@@ -77,14 +77,17 @@ export function PokemonDetailPage() {
                 {pokemonDetail.data.name}
               </Heading>
               <Box display={'flex'} gap={'1'}>
-                <Img src={renderType(pokemonDetail.data.types[0].type.name)} />
-                {pokemonDetail.data.types[0] ? (
+                {/* First type badge (ex: "Bug"): */}
+                <Img
+                  src={renderType(pokemonDetail.data.types[0].type.name)}
+                />
+                {/* Second type badge (ex: "Poison") (if available):  */}
+                {
+                  pokemonDetail.data.types.length > 1 &&
                   <Img
                     src={renderType(pokemonDetail.data.types[1].type.name)}
                   />
-                ) : (
-                  ''
-                )}
+                }
               </Box>
             </Box>
             <Image
@@ -164,16 +167,17 @@ export function PokemonDetailPage() {
                     {pokemonDetail.data.name}
                   </Heading>
                   <Box display={'flex'} gap={'1'}>
+                    {/* First type badge (ex: "Bug"): */}
                     <Img
                       src={renderType(pokemonDetail.data.types[0].type.name)}
                     />
-                    {pokemonDetail.data.types[0] ? (
+                    {/* Second type badge (ex: "Poison") (if available):  */}
+                    {
+                      pokemonDetail.data.types.length > 1 &&
                       <Img
                         src={renderType(pokemonDetail.data.types[1].type.name)}
                       />
-                    ) : (
-                      ''
-                    )}
+                    }
                   </Box>
                 </Box>
                 <Image


### PR DESCRIPTION
A página de "Detalhes" do Pokemon não carregava se o mesmo só tivesse 1 tipo (Charmander é só "Fogo", quando Charizard é "Fogo/Voador").

Erro do console: "TypeError: undefined is not an object (evaluating 'i.data.types[1].type')"

Como o valor de "pokemonDetail.data.types[0]" sempre retorna "true", ele tentava renderizar o "types[1]" sempre, mesmo quando era undefined. Agora, ele checa o tamanho do array de "types".


Projeto muito legal e criativo!

